### PR TITLE
Fix hero icon path

### DIFF
--- a/ow2_tracker_final_hover_fixed.py
+++ b/ow2_tracker_final_hover_fixed.py
@@ -16,7 +16,10 @@ MID_BG = "#11212D"
 LIGHT_BG = "#253745"
 FONT_COLOR = "#ffffff"
 MODERN_FONT = ("Segoe UI", 10)
-ICON_DIR = r"C:\Users\User\Desktop\OW2Tracker\Official\hero_icons"
+# Directory containing the hero icon images.  The icons are bundled with the
+# project inside the ``hero_icons`` folder, so build the path relative to this
+# file to ensure it works regardless of where the script is run from.
+ICON_DIR = os.path.join(os.path.dirname(__file__), "hero_icons")
 
 # Globals
 match_log = []


### PR DESCRIPTION
## Summary
- point ICON_DIR to hero_icons folder in repo

## Testing
- `python -m py_compile ow2_tracker_final_hover_fixed.py`


------
https://chatgpt.com/codex/tasks/task_e_6878894a90588325bb40965ac4b5d220